### PR TITLE
Import xrange from six.moves

### DIFF
--- a/samyro/integerize.py
+++ b/samyro/integerize.py
@@ -3,11 +3,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-
 import random
 
 import prettytensor
 import tensorflow
+from six.moves import xrange
 
 UNK = 0
 BOS = 2  # officially STX "START TEXT"


### PR DESCRIPTION
Fix #1 [edit by @jkahn]

Import xrange from six.moves so that the code is compatible with Python 3.

This fixes Issue #1.
