### PR TITLE
Add if/main idiom to all cli scripts

### DIFF
--- a/samyro/cli/learn.py
+++ b/samyro/cli/learn.py
@@ -118,3 +118,6 @@ def main():
     args = parser.parse_args()
 
     execute(args)
+
+if __name__ == "__main__":
+    main()

--- a/samyro/cli/sample.py
+++ b/samyro/cli/sample.py
@@ -58,10 +58,14 @@ def main():
     # shared_parent = samyro.cli.shared.set_shared_args()
 
     parser = argparse.ArgumentParser(prog='samyro-sample',
-                                     fromfile_prefix_chars='@',)
+                                     fromfile_prefix_chars='@', )
 
     set_sampler_args(parser)
 
     args = parser.parse_args()
 
     execute(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/samyro/cli/shared.py
+++ b/samyro/cli/shared.py
@@ -3,15 +3,13 @@ import os
 
 import prettytensor as pt
 
+import samyro.cli.learn
+import samyro.cli.sample
+import samyro.cli.write
 import samyro.learn
 import samyro.model
 import samyro.read
 import samyro.write
-
-import samyro.cli.learn
-import samyro.cli.write
-import samyro.cli.sample
-
 from samyro.cli import positive_int
 
 
@@ -134,3 +132,7 @@ def main():
     args = parser.parse_args()
 
     args.execute(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/samyro/cli/write.py
+++ b/samyro/cli/write.py
@@ -1,11 +1,12 @@
 from __future__ import print_function
 
 import argparse
+
 import tensorflow as tf
 
-from samyro.cli import positive_int, positive_float
 import samyro.cli.shared
 import samyro.integerize
+from samyro.cli import positive_int, positive_float
 
 
 def execute(args):
@@ -53,3 +54,7 @@ def main():
     args = parser.parse_args()
 
     execute(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Run the main() function if a cli script if launched as its own Python program.

This is helpful for IDEs like Pycharm, which require that you specify
a script in your run configuration and not just a function inside a script.

The resolves Issue #4.
